### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@
 name = "yaxpeax-riscv"
 edition = "2021"
 version = "0.1.0"
-authors = [ "Justin Moore <me@justinm.one>" ]
+authors = ["Justin Moore <me@justinm.one>"]
 license = "0BSD"
 repository = "https://github.com/DrChat/yaxpeax-riscv/"
 description = "risc-v decoders for the yaxpeax project"
 
 [dependencies]
-yaxpeax-arch = { version = "0.2.2", default-features = false, features = [] }
+yaxpeax-arch = { version = "0.3.2", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-num_enum = { version = "0.2", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5.1"
 
 [[test]]
 name = "test"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,16 @@ impl Instruction {
         }
     }
 
-    fn opcode(&self) -> &Opcode {
+    pub fn opcode(&self) -> &Opcode {
         &self.opcode
+    }
+
+    pub fn operands(&self) -> &[Operand] {
+        &self.operands
+    }
+
+    pub fn word(&self) -> &u32 {
+        &self.word
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,10 @@ impl Instruction {
             )),
         }
     }
+
+    fn opcode(&self) -> &Opcode {
+        &self.opcode
+    }
 }
 
 impl yaxpeax_arch::Instruction for Instruction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ impl Instruction {
         &self.opcode
     }
 
-    pub fn operands(&self) -> &[Operand; 3] {
-        &self.operands
+    pub fn operands(&self) -> Vec<Option<Operand>> {
+        self.operands.iter().map(|o| self.operand(o)).collect::<Vec<_>>()
     }
 
     pub fn word(&self) -> &u32 {
@@ -375,7 +375,7 @@ impl RiscVDecoder {
             }
             0b000_1111 => {
                 // FENCE opcode group
-                todo!()
+                Err(StandardDecodeError::InvalidOpcode)?
             }
             0b111_0011 => match (opc >> 20) & 0b1111_1111_1111 {
                 0b0000_0000_0000 => instruction.opcode = Opcode::ECALL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub enum Opcode {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum FieldSpec {
+pub enum FieldSpec {
     Rs1,
     Rs2,
     Rd,
@@ -191,7 +191,7 @@ enum FieldSpec {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-enum OperandSpec {
+pub enum OperandSpec {
     Nothing = 0,
     Rs1,
     Rs2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl Instruction {
         &self.opcode
     }
 
-    pub fn operands(&self) -> &[Operand] {
+    pub fn operands(&self) -> &[Operand; 3] {
         &self.operands
     }
 


### PR DESCRIPTION
Yaxpeax has had its first major update in a while to version 3.0. This crate is already compatible, so this just bumps up the dependency version.